### PR TITLE
🐛 認証済みページの静的生成エラーを修正

### DIFF
--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { getServerCurrentUser } from "@/app/services/api/supabase-server";
 import { fetchUserInfoByAuthId } from "@/app/services/api/users-server";
 import { checkAdminPermissions, checkInstructorPermissions } from "@/app/services/auth/permissions";


### PR DESCRIPTION
## Summary
- `(authenticated)/layout.tsx` に `export const dynamic = "force-dynamic"` を追加
- Vercelデプロイ時に発生していた `DYNAMIC_SERVER_USAGE` エラーを解消
- 認証済みルート配下の全ページ（admin, instructor, learn, submissions等）が対象

## 原因
`(authenticated)/layout.tsx` が `getServerCurrentUser()` → `cookies()` を呼び出しているため、Next.js 16のビルド時に静的生成が失敗していた。

## Test plan
- [ ] `bun run build` がエラーなく完了すること
- [ ] Vercelプレビューデプロイが成功すること
- [ ] 認証済みページが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)