### PR TITLE
🐛 middlewareのリダイレクトループを防止

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -18,7 +18,10 @@ function shouldSkipMiddleware(pathname: string): boolean {
     pathname.startsWith("/_next") ||
     pathname.startsWith("/api") ||
     pathname.includes(".") ||
-    pathname === "/favicon.ico"
+    pathname === "/favicon.ico" ||
+    pathname === "/login" ||
+    pathname === "/pending" ||
+    pathname === "/rejected"
   );
 }
 
@@ -81,6 +84,14 @@ export async function middleware(request: NextRequest) {
     // 未認証の場合はポータルのログインページにリダイレクト
     if (error || !user) {
       const redirectUrl = new URL("/login", PORTAL_URL);
+      // リダイレクト先が自身のオリジンと同じ場合はループ防止のためスキップ
+      if (redirectUrl.origin === request.nextUrl.origin) {
+        console.error(
+          "[middleware] PORTAL_URL is same as current origin, skipping redirect to prevent loop:",
+          PORTAL_URL
+        );
+        return response;
+      }
       redirectUrl.searchParams.set("redirect", request.url);
       return NextResponse.redirect(redirectUrl);
     }


### PR DESCRIPTION
## Summary
- `/login`, `/pending`, `/rejected` パスをmiddlewareのスキップ対象に追加（このサービスに存在しないルート）
- リダイレクト先が自身のオリジンと一致する場合のフェイルセーフチェックを追加

## 原因
未認証ユーザーがアクセスした際、middlewareが `/login` にリダイレクト → `/login` が再びmiddlewareでインターセプト → 再度リダイレクト → 無限ループでURLが肥大化し500エラーに。

`PORTAL_URL` が正しく設定されていても、ビルド時のインライン化や設定ミスでリダイレクト先が自身のオリジンになるケースに対応するオリジンチェックも追加。

## Test plan
- [ ] `bun run build` がエラーなく完了すること
- [ ] Vercelプレビューデプロイが成功すること
- [ ] 未認証状態でアクセスした際にリダイレクトループが発生しないこと
- [ ] Vercelビルドログで `NEXT_PUBLIC_PORTAL_URL` が正しくインライン化されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)