### PR TITLE
docs: mainへの直接コミット禁止のブランチ運用ルールを追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ bun run test:all     # build/db:types/lint/format/check/test を一括実行
 - ブランチ名は変更内容が分かる接頭辞付きで命名する（例: `feature/...`、`fix/...`、`docs/...`、`refactor/...`）。
 - 変更は作業ブランチへコミットし、`main` への反映は必ずプルリクエスト経由で行う。
 - `main` への force push は禁止。
+- **リモートへ push する前には、対象ブランチを問わず必ずユーザーに確認を取ること。** ユーザーの承認を得てから push を実行する。
 
 ## プルリクエスト
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,13 @@ bun run test         # Vitestによるユニットテスト実行
 bun run test:all     # build/db:types/lint/format/check/test を一括実行
 ```
 
+## ブランチ運用
+
+- **`main` ブランチへ直接コミット・直接 push してはならない。** バグ修正・機能追加・ドキュメント更新などあらゆる変更は、必ず作業用のブランチを切ってから行うこと。
+- ブランチ名は変更内容が分かる接頭辞付きで命名する（例: `feature/...`、`fix/...`、`docs/...`、`refactor/...`）。
+- 変更は作業ブランチへコミットし、`main` への反映は必ずプルリクエスト経由で行う。
+- `main` への force push は禁止。
+
 ## プルリクエスト
 
 PRを作成する際は必ず `.github/pull_request_template.md` のテンプレートに従うこと。


### PR DESCRIPTION
## 概要

<!-- 変更の背景・理由と、変更の概要を記載してください -->

- `main` ブランチへの直接コミット・直接 push を禁止し、変更は必ず作業ブランチを切って PR 経由で反映する旨を CLAUDE.md に明記する。
- 背景: GAS学習（応用編）の提出方法の案内追記（`8d84f01`）を誤って `main` に直接 push してしまったため、再発防止のガードレールとしてルールを文書化する。

### 関連Issue

<!-- 関連するIssue番号を記載してください -->

- なし

## 技術的変更点

<!-- レビュワーに変更の流れが分かるように、どの処理をどう変更したか、どう動くのか、などを記載してください -->

- `CLAUDE.md` に「ブランチ運用」セクションを新設し、以下を明記:
  - `main` への直接コミット・直接 push の禁止
  - ブランチ名は接頭辞付き（`feature/`・`fix/`・`docs/`・`refactor/` 等）
  - `main` への反映は必ず PR 経由
  - `main` への force push 禁止

### レビュー特記事項

<!-- レビュワーに重点的に確認してもらいたい観点や、レビュワーに伝えたい実装意図 -->

- 本来は提出方法の案内追記（A対応）もこのブランチ経由で PR する想定でしたが、当該コミット（`8d84f01`）が既に `main` にマージ済みのため、非破壊方針（履歴を書き換えない）に従い `main` 上にそのまま残しています。そのため本PRの差分は CLAUDE.md のルール追記のみです。

### TODO事項

<!-- 今回あえて修正を保留した箇所 -->

- なし

## 動作確認内容

<!-- 動作確認した内容（環境、ケース） -->

- ドキュメントのみの変更のため動作確認は不要。

## その他

<!-- マージ順番の制約や急ぎ対応など -->

- なし

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語を使ってください。 -->
