### PR TITLE
feat: スライドアップロードをフォルダ指定・連番ファイル名に対応

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ app/
 - **user_progress**: コンテンツごとの完了状態を記録（user+contentでユニーク）
 - **submissions**: 演習コンテンツに紐づくコードまたはURLの提出物
 
-スライドPDFは Supabase Storage の `slides` バケットに **`slides/<コーススラッグ>/slide-NN.pdf`**（NNは2桁ゼロ埋め）の命名規約で保存する（例: `slides/gas/slide-01.pdf`、`slides/gas-advanced/slide-03.pdf`）。アップロードAPI（`app/api/upload-pdf/route.ts`）はフォルダ指定＋連番（自動採番／番号指定）に対応しており、シードSQL（`supabase/migrations/03_seed/`）もこのパスを前提とする。
+スライドPDFは Supabase Storage の `slides` バケット内に、オブジェクトキー **`<コーススラッグ>/slide-NN.pdf`**（NNは最低2桁のゼロ埋め）で保存する（例: キー `gas-advanced/slide-03.pdf` → 公開URL `.../storage/v1/object/public/slides/gas-advanced/slide-03.pdf`）。アップロードAPI（`app/api/upload-pdf/route.ts`）はフォルダ指定＋連番（自動採番／番号指定）に対応しており、シードSQL（`supabase/migrations/03_seed/`）もこのパスを前提とする。
 
 セキュリティはデータベースレベルの**Row Level Security (RLS)** ポリシーで実現。公開コンテンツは認証済み全ユーザーが閲覧可能、進捗・提出物は本人のみ、管理者は全データの読み書きが可能。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,8 @@ app/
 - **user_progress**: コンテンツごとの完了状態を記録（user+contentでユニーク）
 - **submissions**: 演習コンテンツに紐づくコードまたはURLの提出物
 
+スライドPDFは Supabase Storage の `slides` バケットに **`slides/<コーススラッグ>/slide-NN.pdf`**（NNは2桁ゼロ埋め）の命名規約で保存する（例: `slides/gas/slide-01.pdf`、`slides/gas-advanced/slide-03.pdf`）。アップロードAPI（`app/api/upload-pdf/route.ts`）はフォルダ指定＋連番（自動採番／番号指定）に対応しており、シードSQL（`supabase/migrations/03_seed/`）もこのパスを前提とする。
+
 セキュリティはデータベースレベルの**Row Level Security (RLS)** ポリシーで実現。公開コンテンツは認証済み全ユーザーが閲覧可能、進捗・提出物は本人のみ、管理者は全データの読み書きが可能。
 
 ### サービス層 (`app/services/`)

--- a/app/(authenticated)/manage/contents/ContentForm.tsx
+++ b/app/(authenticated)/manage/contents/ContentForm.tsx
@@ -48,6 +48,19 @@ const SUBMISSION_TYPE_OPTIONS: {
   { value: "both", label: "コード・URL選択", description: "受講生がどちらかを選択して提出" },
 ];
 
+/**
+ * 既存スライドの pdf_url（例: .../slides/gas-advanced/slide-03.pdf）から
+ * コーススラッグとスライド番号を抽出する。命名規約に沿わない場合は空を返す。
+ */
+function parseSlidePath(pdfUrl: string | null | undefined): {
+  folder: string;
+  slideNumber: string;
+} {
+  const match = pdfUrl?.match(/\/slides\/([a-z0-9-]+)\/slide-(\d+)\.pdf$/);
+  if (!match) return { folder: "", slideNumber: "" };
+  return { folder: match[1], slideNumber: String(Number.parseInt(match[2], 10)) };
+}
+
 export function ContentForm({ weeks, initialData, mode }: ContentFormProps) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -67,16 +80,21 @@ export function ContentForm({ weeks, initialData, mode }: ContentFormProps) {
   const [codeLanguage, setCodeLanguage] = useState<CodeLanguage>(
     (initialData?.code_language as CodeLanguage) ?? "javascript"
   );
+  const initialSlide = parseSlidePath(initialData?.pdf_url);
   const [pdfUrl, setPdfUrl] = useState(initialData?.pdf_url ?? "");
-  const [pdfFolder, setPdfFolder] = useState("");
-  const [slideNumber, setSlideNumber] = useState("");
+  const [pdfFolder, setPdfFolder] = useState(initialSlide.folder);
+  const [slideNumber, setSlideNumber] = useState(initialSlide.slideNumber);
   const [displayOrder, setDisplayOrder] = useState(initialData?.display_order?.toString() ?? "0");
   const [isPublished, setIsPublished] = useState(initialData?.is_published ?? false);
 
   const [isLoading, setIsLoading] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
-  const [pdfFileName, setPdfFileName] = useState<string | null>(null);
+  const [pdfFileName, setPdfFileName] = useState<string | null>(
+    initialSlide.folder
+      ? `${initialSlide.folder}/slide-${initialSlide.slideNumber.padStart(2, "0")}.pdf`
+      : null
+  );
 
   const handlePdfUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/app/(authenticated)/manage/contents/ContentForm.tsx
+++ b/app/(authenticated)/manage/contents/ContentForm.tsx
@@ -68,6 +68,8 @@ export function ContentForm({ weeks, initialData, mode }: ContentFormProps) {
     (initialData?.code_language as CodeLanguage) ?? "javascript"
   );
   const [pdfUrl, setPdfUrl] = useState(initialData?.pdf_url ?? "");
+  const [pdfFolder, setPdfFolder] = useState("");
+  const [slideNumber, setSlideNumber] = useState("");
   const [displayOrder, setDisplayOrder] = useState(initialData?.display_order?.toString() ?? "0");
   const [isPublished, setIsPublished] = useState(initialData?.is_published ?? false);
 
@@ -85,12 +87,35 @@ export function ContentForm({ weeks, initialData, mode }: ContentFormProps) {
       return;
     }
 
+    const folder = pdfFolder.trim().toLowerCase();
+    if (!folder) {
+      setMessage({ type: "error", text: "保存先フォルダ（コーススラッグ）を入力してください" });
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      return;
+    }
+    if (!/^[a-z0-9-]+$/.test(folder)) {
+      setMessage({
+        type: "error",
+        text: "フォルダ名は英小文字・数字・ハイフンのみ使用できます",
+      });
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      return;
+    }
+
     setIsUploading(true);
     setMessage(null);
 
     try {
       const formData = new FormData();
       formData.append("file", file);
+      formData.append("folder", folder);
+      if (slideNumber.trim()) {
+        formData.append("slideNumber", slideNumber.trim());
+      }
 
       const response = await fetch("/api/upload-pdf", {
         method: "POST",
@@ -100,8 +125,8 @@ export function ContentForm({ weeks, initialData, mode }: ContentFormProps) {
       if (response.ok) {
         const data = await response.json();
         setPdfUrl(data.url);
-        setPdfFileName(file.name);
-        setMessage({ type: "success", text: "PDFをアップロードしました" });
+        setPdfFileName(data.path ?? file.name);
+        setMessage({ type: "success", text: `スライドをアップロードしました（${data.path}）` });
       } else {
         const data = await response.json();
         setMessage({ type: "error", text: data.error || "アップロードに失敗しました" });
@@ -251,6 +276,36 @@ export function ContentForm({ weeks, initialData, mode }: ContentFormProps) {
 
           {contentType === "slide" && (
             <div className="space-y-3">
+              {/* 保存先フォルダ・スライド番号 */}
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="pdfFolder">保存先フォルダ（コーススラッグ）</Label>
+                  <Input
+                    id="pdfFolder"
+                    value={pdfFolder}
+                    onChange={(e) => setPdfFolder(e.target.value)}
+                    placeholder="例: gas-advanced"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    slides/&lt;フォルダ&gt;/slide-NN.pdf
+                    として保存されます（英小文字・数字・ハイフン）
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="slideNumber">スライド番号</Label>
+                  <Input
+                    id="slideNumber"
+                    type="number"
+                    min={1}
+                    value={slideNumber}
+                    onChange={(e) => setSlideNumber(e.target.value)}
+                    placeholder="空欄で自動採番"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    指定するとその番号で保存（既存は上書き）。空欄なら次の番号を自動採番。
+                  </p>
+                </div>
+              </div>
               <Label>PDFファイル</Label>
               <div className="flex items-center gap-3">
                 <Button

--- a/app/api/upload-pdf/route.ts
+++ b/app/api/upload-pdf/route.ts
@@ -6,6 +6,36 @@ import { checkContentPermissions } from "@/app/services/auth/permissions";
 const BUCKET_NAME = "slides";
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
+// フォルダ名（コーススラッグ）は英小文字・数字・ハイフンのみ許可
+const FOLDER_PATTERN = /^[a-z0-9-]+$/;
+// 命名規約に沿ったスライドファイル名（slide-NN.pdf）
+const SLIDE_FILE_PATTERN = /^slide-(\d+)\.pdf$/;
+
+/**
+ * 指定フォルダ内の既存 slide-NN.pdf を走査し、次に使う連番（最大値+1）を返す。
+ * 既存が無ければ 1 を返す。
+ */
+async function getNextSlideNumber(
+  supabase: Awaited<ReturnType<typeof createAdminSupabaseClient>>,
+  folder: string
+): Promise<number> {
+  const { data, error } = await supabase.storage.from(BUCKET_NAME).list(folder, { limit: 1000 });
+
+  if (error || !data) {
+    return 1;
+  }
+
+  let maxNumber = 0;
+  for (const item of data) {
+    const match = item.name.match(SLIDE_FILE_PATTERN);
+    if (match) {
+      maxNumber = Math.max(maxNumber, Number.parseInt(match[1], 10));
+    }
+  }
+
+  return maxNumber + 1;
+}
+
 export async function POST(request: NextRequest) {
   try {
     const auth = await getApiAuth();
@@ -45,10 +75,48 @@ export async function POST(request: NextRequest) {
 
     const supabase = await createAdminSupabaseClient();
 
-    // ユニークなファイル名を生成
-    const timestamp = Date.now();
-    const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
-    const filePath = `${timestamp}_${safeName}`;
+    // 保存先フォルダ（コーススラッグ）とスライド番号を取得
+    const folderRaw = (formData.get("folder") as string | null)?.trim() ?? "";
+    const slideNumberRaw = (formData.get("slideNumber") as string | null)?.trim() ?? "";
+
+    let filePath: string;
+    // フォルダ指定時は命名規約 slides/<folder>/slide-NN.pdf に沿って保存
+    let allowOverwrite = false;
+
+    if (folderRaw) {
+      const folder = folderRaw.toLowerCase();
+      if (!FOLDER_PATTERN.test(folder)) {
+        return NextResponse.json(
+          { error: "フォルダ名は英小文字・数字・ハイフンのみ使用できます" },
+          { status: 400 }
+        );
+      }
+
+      let slideNumber: number;
+      if (slideNumberRaw) {
+        // 番号指定時：その番号で保存（既存ファイルは上書き）
+        const parsed = Number.parseInt(slideNumberRaw, 10);
+        if (!Number.isInteger(parsed) || parsed < 1) {
+          return NextResponse.json(
+            { error: "スライド番号は1以上の整数を指定してください" },
+            { status: 400 }
+          );
+        }
+        slideNumber = parsed;
+        allowOverwrite = true;
+      } else {
+        // 番号未指定時：同フォルダ内の既存連番から自動採番
+        slideNumber = await getNextSlideNumber(supabase, folder);
+      }
+
+      const paddedNumber = String(slideNumber).padStart(2, "0");
+      filePath = `${folder}/slide-${paddedNumber}.pdf`;
+    } else {
+      // フォルダ未指定時は従来のタイムスタンプ付きファイル名（後方互換）
+      const timestamp = Date.now();
+      const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+      filePath = `${timestamp}_${safeName}`;
+    }
 
     const arrayBuffer = await file.arrayBuffer();
     const buffer = new Uint8Array(arrayBuffer);
@@ -57,17 +125,22 @@ export async function POST(request: NextRequest) {
       .from(BUCKET_NAME)
       .upload(filePath, buffer, {
         contentType: "application/pdf",
-        upsert: false,
+        upsert: allowOverwrite,
       });
 
     if (uploadError) {
       console.error("PDFアップロードエラー:", uploadError);
-      return NextResponse.json({ error: "アップロードに失敗しました" }, { status: 500 });
+      // 自動採番中に同名ファイルが存在した場合（409 Conflict）はその旨を明示
+      const isDuplicate = uploadError.status === 409 || uploadError.statusCode === "Duplicate";
+      const message = isDuplicate
+        ? "同じ番号のスライドが既に存在します。番号を指定して上書きしてください"
+        : "アップロードに失敗しました";
+      return NextResponse.json({ error: message }, { status: 500 });
     }
 
     const { data: urlData } = supabase.storage.from(BUCKET_NAME).getPublicUrl(filePath);
 
-    return NextResponse.json({ url: urlData.publicUrl });
+    return NextResponse.json({ url: urlData.publicUrl, path: filePath });
   } catch (error) {
     console.error("API エラー:", error);
     return NextResponse.json({ error: "内部エラーが発生しました" }, { status: 500 });

--- a/app/api/upload-pdf/route.ts
+++ b/app/api/upload-pdf/route.ts
@@ -14,6 +14,8 @@ const SLIDE_FILE_PATTERN = /^slide-(\d+)\.pdf$/;
 /**
  * 指定フォルダ内の既存 slide-NN.pdf を走査し、次に使う連番（最大値+1）を返す。
  * 既存が無ければ 1 を返す。
+ * 一覧取得に失敗した場合は走査失敗を区別できないため例外を投げる
+ * （誤った自動採番で既存ファイルを上書き／409誤判定するのを防ぐ）。
  */
 async function getNextSlideNumber(
   supabase: Awaited<ReturnType<typeof createAdminSupabaseClient>>,
@@ -22,7 +24,7 @@ async function getNextSlideNumber(
   const { data, error } = await supabase.storage.from(BUCKET_NAME).list(folder, { limit: 1000 });
 
   if (error || !data) {
-    return 1;
+    throw new Error(`スライド一覧の取得に失敗しました: ${error?.message ?? "unknown error"}`);
   }
 
   let maxNumber = 0;
@@ -106,7 +108,15 @@ export async function POST(request: NextRequest) {
         allowOverwrite = true;
       } else {
         // 番号未指定時：同フォルダ内の既存連番から自動採番
-        slideNumber = await getNextSlideNumber(supabase, folder);
+        try {
+          slideNumber = await getNextSlideNumber(supabase, folder);
+        } catch (listError) {
+          console.error("スライド一覧取得エラー:", listError);
+          return NextResponse.json(
+            { error: "スライド一覧の取得に失敗しました。時間をおいて再度お試しください" },
+            { status: 500 }
+          );
+        }
       }
 
       const paddedNumber = String(slideNumber).padStart(2, "0");

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -401,22 +401,35 @@ Theme / Phase / Week / コンテンツそれぞれに対してCRUD操作が可�
 
 **アクセス権限**: `admin` または `maintainer` ロール
 
-**リクエスト**: `multipart/form-data` で PDF ファイルを送信（最大50MB）
+**リクエスト**: `multipart/form-data`（最大50MB）
+
+| フィールド | 必須 | 説明 |
+|:--|:--|:--|
+| `file` | ○ | アップロードする PDF ファイル |
+| `folder` | - | 保存先フォルダ（コーススラッグ。例: `gas-advanced`）。英小文字・数字・ハイフンのみ |
+| `slideNumber` | - | スライド番号（1以上の整数）。`folder` 指定時のみ有効 |
+
+**命名規約**: スライドは `slides/<コーススラッグ>/slide-NN.pdf`（NN は2桁ゼロ埋め）として保存する。例: `slides/gas/slide-01.pdf`、`slides/gas-advanced/slide-03.pdf`。
 
 **処理フロー**:
 1. 認証チェック
 2. ロール確認（admin / maintainer のみ許可）
-3. Supabase Storage の `slides` バケットにアップロード
-4. 公開 URL を返却
+3. 保存先パスの決定
+   - `folder` 指定あり: `slides/<folder>/slide-NN.pdf`
+     - `slideNumber` 指定あり → その番号で保存（同名ファイルは上書き）
+     - `slideNumber` 指定なし → 同フォルダ内の既存 `slide-NN.pdf` を走査し、最大値+1 で自動採番
+   - `folder` 指定なし: 後方互換のため `<timestamp>_<sanitizedName>` でバケット直下に保存
+4. Supabase Storage の `slides` バケットにアップロード
+5. 公開 URL と保存パスを返却
 
 **レスポンス**:
 
 | ステータス | 条件 |
 |:--|:--|
-| 200 | 正常（`{ url: string }` を返却） |
-| 400 | ファイルなし / サイズ超過 / PDF以外 |
+| 200 | 正常（`{ url: string, path: string }` を返却） |
+| 400 | ファイルなし / サイズ超過 / PDF以外 / フォルダ名不正 / 番号不正 |
 | 403 | 権限なし |
-| 500 | アップロード失敗 / サーバーエラー |
+| 500 | アップロード失敗（自動採番中の重複含む） / サーバーエラー |
 
 ### 6.1.2 AIレビュー API
 
@@ -685,3 +698,4 @@ GET /auth/callback
 | 2026年4月 | ユーザー管理画面にロール変更機能を追加（2.6節・6.1.3節・7.4節を更新） |
 | 2026年4月 | コンテンツ階層にThemeを追加し4階層化（3.1〜3.3節更新）。管理ルートを /manage に移行（6.1節・7.3節更新）。AIレビューAPI・PDFアップロードAPI追加（6.1.1〜6.1.2節）。スライドコンテンツ種別・PDF Viewerコンポーネント追記 |
 | 2026年4月 | Slack通知機能を追加（セクション9）。アーキテクチャ図・レイヤー構成にNotification Servicesを追加 |
+| 2026年5月 | PDFアップロードAPIに保存先フォルダ・連番ファイル名（`slides/<コース>/slide-NN.pdf`）対応を追加（6.1.1節）。自動採番・番号指定上書きに対応 |

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -409,15 +409,15 @@ Theme / Phase / Week / コンテンツそれぞれに対してCRUD操作が可�
 | `folder` | - | 保存先フォルダ（コーススラッグ。例: `gas-advanced`）。英小文字・数字・ハイフンのみ |
 | `slideNumber` | - | スライド番号（1以上の整数）。`folder` 指定時のみ有効 |
 
-**命名規約**: スライドは `slides/<コーススラッグ>/slide-NN.pdf`（NN は2桁ゼロ埋め）として保存する。例: `slides/gas/slide-01.pdf`、`slides/gas-advanced/slide-03.pdf`。
+**命名規約**: スライドは `slides` バケット内にオブジェクトキー `<コーススラッグ>/slide-NN.pdf` で保存する（NN は最低2桁のゼロ埋め。1〜99は `01`〜`99`、100以上は `100` のように桁が増える）。例: キー `gas/slide-01.pdf`・`gas-advanced/slide-03.pdf` → 公開URL `.../storage/v1/object/public/slides/gas/slide-01.pdf`。
 
 **処理フロー**:
 1. 認証チェック
 2. ロール確認（admin / maintainer のみ許可）
-3. 保存先パスの決定
-   - `folder` 指定あり: `slides/<folder>/slide-NN.pdf`
+3. 保存先オブジェクトキーの決定
+   - `folder` 指定あり: `<folder>/slide-NN.pdf`
      - `slideNumber` 指定あり → その番号で保存（同名ファイルは上書き）
-     - `slideNumber` 指定なし → 同フォルダ内の既存 `slide-NN.pdf` を走査し、最大値+1 で自動採番
+     - `slideNumber` 指定なし → 同フォルダ内の既存 `slide-NN.pdf` を走査し、最大値+1 で自動採番（走査失敗時は500）
    - `folder` 指定なし: 後方互換のため `<timestamp>_<sanitizedName>` でバケット直下に保存
 4. Supabase Storage の `slides` バケットにアップロード
 5. 公開 URL と保存パスを返却


### PR DESCRIPTION
## 概要

<!-- 変更の背景・理由と、変更の概要を記載してください -->

- 管理画面のPDFアップロードは保存先・ファイル名が `<timestamp>_<sanitizedName>` 固定で、命名規約 `slides/<コース>/slide-NN.pdf` に沿った保存ができず、アップロード後に手動でリネーム／移動が必要だった（実際にGAS応用編の5件はStorage move APIで手動対応）。
- 恒久対応として、アップロードAPIに**保存先フォルダ指定**と**連番ファイル名（自動採番／番号指定）**対応を追加し、管理画面UIにも入力欄を追加した。

### 関連Issue

<!-- 関連するIssue番号を記載してください -->

- #45

## 技術的変更点

<!-- レビュワーに変更の流れが分かるように、どの処理をどう変更したか、どう動くのか、などを記載してください -->

- `app/api/upload-pdf/route.ts`
  - `multipart/form-data` に `folder`（コーススラッグ）・`slideNumber` を追加で受け取る
  - `folder` 指定時は `slides/<folder>/slide-NN.pdf`（NNは2桁ゼロ埋め）で保存
    - `slideNumber` 未指定 → 同フォルダ内の既存 `slide-NN.pdf` を走査して最大値+1 で**自動採番**（`upsert: false`）
    - `slideNumber` 指定 → その番号で保存（`upsert: true` で**上書き**）
  - フォルダ名は `[a-z0-9-]` のみ許可（不正時400）。自動採番中の重複（409）はエラーメッセージで明示
  - `folder` 未指定時は従来のタイムスタンプ挙動を維持（後方互換）
  - レスポンスに保存パス `path` を追加
- `app/(authenticated)/manage/contents/ContentForm.tsx`
  - スライドセクションに「保存先フォルダ」「スライド番号（空欄で自動採番）」入力欄を追加
  - クライアント側でもフォルダ必須・形式バリデーションを実施し、アップロード後に保存パスを表示
- `docs/specification.md`（6.1.1節）/ `CLAUDE.md`
  - パラメータ・命名規約・処理フロー・レスポンスを更新、改訂履歴・データモデル節に追記

### レビュー特記事項

<!-- レビュワーに重点的に確認してもらいたい観点や、レビュワーに伝えたい実装意図 -->

- フォルダ指定方式は **手入力** を採用。`learning_themes` に slug 列がないため、コース選択からの自動導出にはDB変更が必要と判断し、最小実装としてテキスト入力にした（DBマイグレーション・型再生成は不要）。
- 番号指定時の `upsert: true` は同一パス上書きのため、CDNキャッシュにより旧PDFが一時表示される可能性あり（既存のパスベースURL運用に起因する既知の制約）。

### TODO事項

<!-- 今回あえて修正を保留した箇所があれば記載してください -->

- Issue補足の「既にアップロード済みの誤った名前のファイルを救済する move/リネームユーティリティ」は必須アクション外（「検討余地あり」）のため本PRでは未対応。必要なら別Issueで対応。

## 動作確認内容

<!-- 動作確認した内容（環境、ケース）を記載してください -->

- `bun run check`（Biome リント・フォーマット）: 合格
- `bun run build`（本番ビルド）: 成功
- `bun run test`（Vitest）: 46件全合格

## その他

<!-- マージ順の制約など -->

- 特になし

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語を使ってください。 -->