### PR TITLE
fix: 課題提出の複数ファイル対応改善（デフォルトファイル名の自動補完・言語連動・GAS追加）

### DIFF
--- a/app/(authenticated)/learn/[themeId]/[phaseId]/[weekId]/[contentId]/SubmissionForm.tsx
+++ b/app/(authenticated)/learn/[themeId]/[phaseId]/[weekId]/[contentId]/SubmissionForm.tsx
@@ -23,6 +23,33 @@ interface CodeFileInput {
   filename: string;
   language: CodeLanguage;
   content: string;
+  // ユーザーがファイル名を手動編集したか。false の間は言語変更にあわせて初期値を自動更新する
+  filenameEdited: boolean;
+}
+
+// 言語ごとのデフォルトファイル名（複数ファイル化／言語変更時に自動補完する）
+const DEFAULT_FILENAME_BY_LANGUAGE: Record<CodeLanguage, string> = {
+  javascript: "code.gs",
+  typescript: "code.ts",
+  html: "index.html",
+  css: "style.css",
+};
+
+// 既存のファイル名と衝突しないデフォルトファイル名を生成する（例: index.html → index-2.html）
+function buildDefaultFilename(language: CodeLanguage, existingFilenames: string[]): string {
+  const base = DEFAULT_FILENAME_BY_LANGUAGE[language];
+  const taken = new Set(existingFilenames.map((name) => name.trim()).filter(Boolean));
+  if (!taken.has(base)) {
+    return base;
+  }
+  const dotIndex = base.lastIndexOf(".");
+  const stem = dotIndex === -1 ? base : base.slice(0, dotIndex);
+  const ext = dotIndex === -1 ? "" : base.slice(dotIndex);
+  let counter = 2;
+  while (taken.has(`${stem}-${counter}${ext}`)) {
+    counter += 1;
+  }
+  return `${stem}-${counter}${ext}`;
 }
 
 interface SubmissionFormProps {
@@ -43,7 +70,7 @@ export function SubmissionForm({
     allowedSubmissionTypes === "url" ? "url" : "code"
   );
   const [codeFiles, setCodeFiles] = useState<CodeFileInput[]>([
-    { id: "file-0", filename: "", language: codeLanguage, content: "" },
+    { id: "file-0", filename: "", language: codeLanguage, content: "", filenameEdited: false },
   ]);
   const [url, setUrl] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -57,11 +84,51 @@ export function SubmissionForm({
     setCodeFiles((prev) => prev.map((file, i) => (i === index ? { ...file, ...patch } : file)));
   };
 
+  // ファイル名入力欄の変更。手動編集とみなし、以後は言語変更で初期値を上書きしない
+  const handleFilenameChange = (index: number, filename: string) => {
+    updateCodeFile(index, { filename, filenameEdited: true });
+  };
+
+  // 言語変更。ファイル名が未編集なら、新しい言語のデフォルト名へ追従させる
+  const handleLanguageChange = (index: number, language: CodeLanguage) => {
+    setCodeFiles((prev) =>
+      prev.map((file, i) => {
+        if (i !== index) {
+          return file;
+        }
+        if (file.filenameEdited) {
+          return { ...file, language };
+        }
+        const otherFilenames = prev.filter((_, j) => j !== index).map((f) => f.filename);
+        return { ...file, language, filename: buildDefaultFilename(language, otherFilenames) };
+      })
+    );
+  };
+
   const addCodeFile = () => {
-    setCodeFiles((prev) => [
-      ...prev,
-      { id: crypto.randomUUID(), filename: "", language: codeLanguage, content: "" },
-    ]);
+    setCodeFiles((prev) => {
+      // 単一→複数ファイル化の初回は、ファイル名が空のファイルにデフォルト名を補完する
+      // （単一ファイル時はファイル名欄が非表示で未入力のため、複数化と同時に必須化される対策）
+      const assigned: string[] = prev
+        .map((f) => f.filename)
+        .filter((name) => name.trim().length > 0);
+      const backfilled = prev.map((file) => {
+        if (file.filename.trim().length > 0) {
+          return file;
+        }
+        const filename = buildDefaultFilename(file.language, assigned);
+        assigned.push(filename);
+        return { ...file, filename };
+      });
+      const newFile: CodeFileInput = {
+        id: crypto.randomUUID(),
+        filename: buildDefaultFilename(codeLanguage, assigned),
+        language: codeLanguage,
+        content: "",
+        filenameEdited: false,
+      };
+      return [...backfilled, newFile];
+    });
   };
 
   const removeCodeFile = (index: number) => {
@@ -173,7 +240,15 @@ export function SubmissionForm({
       if (response.ok) {
         const data = await response.json();
         setMessage({ type: "success", text: "提出が完了しました。AIレビューを生成中..." });
-        setCodeFiles([{ id: "file-0", filename: "", language: codeLanguage, content: "" }]);
+        setCodeFiles([
+          {
+            id: "file-0",
+            filename: "",
+            language: codeLanguage,
+            content: "",
+            filenameEdited: false,
+          },
+        ]);
         setUrl("");
 
         const submissionId = data.submission.id;
@@ -255,8 +330,8 @@ export function SubmissionForm({
                       <Input
                         id={`filename-${index}`}
                         value={file.filename}
-                        onChange={(e) => updateCodeFile(index, { filename: e.target.value })}
-                        placeholder="例: コード.gs"
+                        onChange={(e) => handleFilenameChange(index, e.target.value)}
+                        placeholder="例: code.gs"
                       />
                     </div>
                     <div className="space-y-1">
@@ -267,7 +342,7 @@ export function SubmissionForm({
                         id={`language-${index}`}
                         value={file.language}
                         onChange={(e) =>
-                          updateCodeFile(index, { language: e.target.value as CodeLanguage })
+                          handleLanguageChange(index, e.target.value as CodeLanguage)
                         }
                         className="h-9 rounded-md border border-input bg-transparent px-3 text-sm"
                       >

--- a/app/(authenticated)/learn/[themeId]/[phaseId]/[weekId]/[contentId]/SubmissionForm.tsx
+++ b/app/(authenticated)/learn/[themeId]/[phaseId]/[weekId]/[contentId]/SubmissionForm.tsx
@@ -209,7 +209,7 @@ export function SubmissionForm({
 
   const [lastSubmissionId, setLastSubmissionId] = useState<number | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsLoading(true);
     setMessage(null);

--- a/app/(authenticated)/learn/[themeId]/[phaseId]/[weekId]/[contentId]/SubmissionForm.tsx
+++ b/app/(authenticated)/learn/[themeId]/[phaseId]/[weekId]/[contentId]/SubmissionForm.tsx
@@ -4,7 +4,11 @@ import { Code, Link as LinkIcon, Loader2, Plus, Send, Trash2 } from "lucide-reac
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { AIReviewDisplay } from "@/app/components/AIReviewDisplay";
-import { CodeEditor, type CodeLanguage } from "@/app/components/CodeEditor";
+import {
+  CodeEditor,
+  type CodeLanguage,
+  DEFAULT_FILENAME_BY_LANGUAGE,
+} from "@/app/components/CodeEditor";
 import type { AIReview, SubmissionType } from "@/app/types";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -12,8 +16,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 const CODE_LANGUAGE_OPTIONS: { value: CodeLanguage; label: string }[] = [
-  { value: "javascript", label: "JavaScript / GAS" },
+  { value: "javascript", label: "JavaScript" },
   { value: "typescript", label: "TypeScript" },
+  { value: "gas", label: "GAS" },
   { value: "html", label: "HTML" },
   { value: "css", label: "CSS" },
 ];
@@ -26,14 +31,6 @@ interface CodeFileInput {
   // ユーザーがファイル名を手動編集したか。false の間は言語変更にあわせて初期値を自動更新する
   filenameEdited: boolean;
 }
-
-// 言語ごとのデフォルトファイル名（複数ファイル化／言語変更時に自動補完する）
-const DEFAULT_FILENAME_BY_LANGUAGE: Record<CodeLanguage, string> = {
-  javascript: "code.gs",
-  typescript: "code.ts",
-  html: "index.html",
-  css: "style.css",
-};
 
 // 既存のファイル名と衝突しないデフォルトファイル名を生成する（例: index.html → index-2.html）
 function buildDefaultFilename(language: CodeLanguage, existingFilenames: string[]): string {
@@ -331,7 +328,7 @@ export function SubmissionForm({
                         id={`filename-${index}`}
                         value={file.filename}
                         onChange={(e) => handleFilenameChange(index, e.target.value)}
-                        placeholder="例: code.gs"
+                        placeholder={`例: ${DEFAULT_FILENAME_BY_LANGUAGE[file.language]}`}
                       />
                     </div>
                     <div className="space-y-1">

--- a/app/(authenticated)/learn/[themeId]/[phaseId]/[weekId]/[contentId]/SubmissionForm.tsx
+++ b/app/(authenticated)/learn/[themeId]/[phaseId]/[weekId]/[contentId]/SubmissionForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { AIReviewDisplay } from "@/app/components/AIReviewDisplay";
 import {
+  buildDefaultFilename,
   CodeEditor,
   type CodeLanguage,
   DEFAULT_FILENAME_BY_LANGUAGE,
@@ -30,23 +31,6 @@ interface CodeFileInput {
   content: string;
   // ユーザーがファイル名を手動編集したか。false の間は言語変更にあわせて初期値を自動更新する
   filenameEdited: boolean;
-}
-
-// 既存のファイル名と衝突しないデフォルトファイル名を生成する（例: index.html → index-2.html）
-function buildDefaultFilename(language: CodeLanguage, existingFilenames: string[]): string {
-  const base = DEFAULT_FILENAME_BY_LANGUAGE[language];
-  const taken = new Set(existingFilenames.map((name) => name.trim()).filter(Boolean));
-  if (!taken.has(base)) {
-    return base;
-  }
-  const dotIndex = base.lastIndexOf(".");
-  const stem = dotIndex === -1 ? base : base.slice(0, dotIndex);
-  const ext = dotIndex === -1 ? "" : base.slice(dotIndex);
-  let counter = 2;
-  while (taken.has(`${stem}-${counter}${ext}`)) {
-    counter += 1;
-  }
-  return `${stem}-${counter}${ext}`;
 }
 
 interface SubmissionFormProps {

--- a/app/(authenticated)/manage/contents/ContentForm.tsx
+++ b/app/(authenticated)/manage/contents/ContentForm.tsx
@@ -159,7 +159,7 @@ export function ContentForm({ weeks, initialData, mode }: ContentFormProps) {
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsLoading(true);
     setMessage(null);

--- a/app/(authenticated)/manage/phases/PhaseForm.tsx
+++ b/app/(authenticated)/manage/phases/PhaseForm.tsx
@@ -28,7 +28,7 @@ export function PhaseForm({ themes, initialData, mode }: PhaseFormProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsLoading(true);
     setMessage(null);

--- a/app/(authenticated)/manage/themes/ThemeForm.tsx
+++ b/app/(authenticated)/manage/themes/ThemeForm.tsx
@@ -27,7 +27,7 @@ export function ThemeForm({ initialData, mode }: ThemeFormProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsLoading(true);
     setMessage(null);

--- a/app/(authenticated)/manage/weeks/WeekForm.tsx
+++ b/app/(authenticated)/manage/weeks/WeekForm.tsx
@@ -30,7 +30,7 @@ export function WeekForm({ phases, initialData, mode }: WeekFormProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsLoading(true);
     setMessage(null);

--- a/app/components/CodeEditor.tsx
+++ b/app/components/CodeEditor.tsx
@@ -6,7 +6,17 @@ import { javascript } from "@codemirror/lang-javascript";
 import CodeMirror from "@uiw/react-codemirror";
 import { useEffect, useState } from "react";
 
-export type CodeLanguage = "javascript" | "typescript" | "html" | "css";
+export type CodeLanguage = "javascript" | "typescript" | "gas" | "html" | "css";
+
+// 言語ごとのデフォルトファイル名（提出フォームの初期値・プレースホルダーに使用）
+// JavaScript(.js) と GAS(.gs) は拡張子が異なるため別言語として扱う
+export const DEFAULT_FILENAME_BY_LANGUAGE: Record<CodeLanguage, string> = {
+  javascript: "code.js",
+  typescript: "code.ts",
+  gas: "code.gs",
+  html: "index.html",
+  css: "style.css",
+};
 
 interface CodeEditorProps {
   value: string;
@@ -19,6 +29,8 @@ interface CodeEditorProps {
 function getExtensions(language: CodeLanguage) {
   switch (language) {
     case "javascript":
+    // GAS（Google Apps Script）はJavaScriptベースのため同じシンタックスを使用する
+    case "gas":
       return [javascript()];
     case "typescript":
       return [javascript({ typescript: true })];

--- a/app/components/CodeEditor.tsx
+++ b/app/components/CodeEditor.tsx
@@ -18,6 +18,23 @@ export const DEFAULT_FILENAME_BY_LANGUAGE: Record<CodeLanguage, string> = {
   css: "style.css",
 };
 
+// 既存のファイル名と衝突しないデフォルトファイル名を生成する（例: index.html → index-2.html）
+export function buildDefaultFilename(language: CodeLanguage, existingFilenames: string[]): string {
+  const base = DEFAULT_FILENAME_BY_LANGUAGE[language];
+  const taken = new Set(existingFilenames.map((name) => name.trim()).filter(Boolean));
+  if (!taken.has(base)) {
+    return base;
+  }
+  const dotIndex = base.lastIndexOf(".");
+  const stem = dotIndex === -1 ? base : base.slice(0, dotIndex);
+  const ext = dotIndex === -1 ? "" : base.slice(dotIndex);
+  let counter = 2;
+  while (taken.has(`${stem}-${counter}${ext}`)) {
+    counter += 1;
+  }
+  return `${stem}-${counter}${ext}`;
+}
+
 interface CodeEditorProps {
   value: string;
   onChange: (value: string) => void;

--- a/app/demo/components/DemoSubmissionForm.tsx
+++ b/app/demo/components/DemoSubmissionForm.tsx
@@ -12,7 +12,11 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { AIReviewDisplay } from "@/app/components/AIReviewDisplay";
-import { CodeEditor, type CodeLanguage } from "@/app/components/CodeEditor";
+import {
+  CodeEditor,
+  type CodeLanguage,
+  DEFAULT_FILENAME_BY_LANGUAGE,
+} from "@/app/components/CodeEditor";
 import type { AIReview, SubmissionType } from "@/app/types";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -20,8 +24,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 const CODE_LANGUAGE_OPTIONS: { value: CodeLanguage; label: string }[] = [
-  { value: "javascript", label: "JavaScript / GAS" },
+  { value: "javascript", label: "JavaScript" },
   { value: "typescript", label: "TypeScript" },
+  { value: "gas", label: "GAS" },
   { value: "html", label: "HTML" },
   { value: "css", label: "CSS" },
 ];
@@ -179,7 +184,7 @@ export function DemoSubmissionForm({
                         id={`demo-filename-${index}`}
                         value={file.filename}
                         onChange={(e) => updateCodeFile(index, { filename: e.target.value })}
-                        placeholder="例: コード.gs"
+                        placeholder={`例: ${DEFAULT_FILENAME_BY_LANGUAGE[file.language]}`}
                       />
                     </div>
                     <div className="space-y-1">

--- a/app/demo/components/DemoSubmissionForm.tsx
+++ b/app/demo/components/DemoSubmissionForm.tsx
@@ -104,7 +104,7 @@ export function DemoSubmissionForm({
     setCodeFiles((prev) => prev.filter((_, i) => i !== index));
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsLoading(true);
     setIsReviewLoading(true);

--- a/app/demo/components/DemoSubmissionForm.tsx
+++ b/app/demo/components/DemoSubmissionForm.tsx
@@ -13,6 +13,7 @@ import {
 import { useState } from "react";
 import { AIReviewDisplay } from "@/app/components/AIReviewDisplay";
 import {
+  buildDefaultFilename,
   CodeEditor,
   type CodeLanguage,
   DEFAULT_FILENAME_BY_LANGUAGE,
@@ -36,6 +37,8 @@ interface CodeFileInput {
   filename: string;
   language: CodeLanguage;
   content: string;
+  // ユーザーがファイル名を手動編集したか。false の間は言語変更にあわせて初期値を自動更新する
+  filenameEdited: boolean;
 }
 
 // デモ用のサンプルAIレビュー（実際のAPI呼び出しは行わない）
@@ -85,7 +88,7 @@ export function DemoSubmissionForm({
     allowedSubmissionTypes === "url" ? "url" : "code"
   );
   const [codeFiles, setCodeFiles] = useState<CodeFileInput[]>([
-    { id: "file-0", filename: "", language: codeLanguage, content: "" },
+    { id: "file-0", filename: "", language: codeLanguage, content: "", filenameEdited: false },
   ]);
   const [url, setUrl] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -98,11 +101,51 @@ export function DemoSubmissionForm({
     setCodeFiles((prev) => prev.map((file, i) => (i === index ? { ...file, ...patch } : file)));
   };
 
+  // ファイル名入力欄の変更。手動編集とみなし、以後は言語変更で初期値を上書きしない
+  const handleFilenameChange = (index: number, filename: string) => {
+    updateCodeFile(index, { filename, filenameEdited: true });
+  };
+
+  // 言語変更。ファイル名が未編集なら、新しい言語のデフォルト名へ追従させる
+  const handleLanguageChange = (index: number, language: CodeLanguage) => {
+    setCodeFiles((prev) =>
+      prev.map((file, i) => {
+        if (i !== index) {
+          return file;
+        }
+        if (file.filenameEdited) {
+          return { ...file, language };
+        }
+        const otherFilenames = prev.filter((_, j) => j !== index).map((f) => f.filename);
+        return { ...file, language, filename: buildDefaultFilename(language, otherFilenames) };
+      })
+    );
+  };
+
   const addCodeFile = () => {
-    setCodeFiles((prev) => [
-      ...prev,
-      { id: crypto.randomUUID(), filename: "", language: codeLanguage, content: "" },
-    ]);
+    setCodeFiles((prev) => {
+      // 単一→複数ファイル化の初回は、ファイル名が空のファイルにデフォルト名を補完する
+      // （単一ファイル時はファイル名欄が非表示で未入力のため、複数化と同時に必須化される対策）
+      const assigned: string[] = prev
+        .map((f) => f.filename)
+        .filter((name) => name.trim().length > 0);
+      const backfilled = prev.map((file) => {
+        if (file.filename.trim().length > 0) {
+          return file;
+        }
+        const filename = buildDefaultFilename(file.language, assigned);
+        assigned.push(filename);
+        return { ...file, filename };
+      });
+      const newFile: CodeFileInput = {
+        id: crypto.randomUUID(),
+        filename: buildDefaultFilename(codeLanguage, assigned),
+        language: codeLanguage,
+        content: "",
+        filenameEdited: false,
+      };
+      return [...backfilled, newFile];
+    });
   };
 
   const removeCodeFile = (index: number) => {
@@ -183,7 +226,7 @@ export function DemoSubmissionForm({
                       <Input
                         id={`demo-filename-${index}`}
                         value={file.filename}
-                        onChange={(e) => updateCodeFile(index, { filename: e.target.value })}
+                        onChange={(e) => handleFilenameChange(index, e.target.value)}
                         placeholder={`例: ${DEFAULT_FILENAME_BY_LANGUAGE[file.language]}`}
                       />
                     </div>
@@ -195,7 +238,7 @@ export function DemoSubmissionForm({
                         id={`demo-language-${index}`}
                         value={file.language}
                         onChange={(e) =>
-                          updateCodeFile(index, { language: e.target.value as CodeLanguage })
+                          handleLanguageChange(index, e.target.value as CodeLanguage)
                         }
                         className="h-9 rounded-md border border-input bg-transparent px-3 text-sm"
                       >


### PR DESCRIPTION
## 概要

<!-- 変更の背景・理由と、変更の概要を記載してください -->

- 課題提出で「＋ファイルを追加」を押して複数ファイルにすると、全ファイルにファイル名が必須となり「提出する」ボタンが押せなくなる不具合を修正。
- 複数ファイル化／言語切り替え時に、言語に応じたデフォルトファイル名を自動補完するよう改善。
- 言語選択肢の「JavaScript / GAS」を、拡張子が異なる「JavaScript」(.js) と「GAS」(.gs) に分離。
- ファイル名のプレースホルダー・デフォルト値が選択言語に追従するよう変更。
- 併せて、フォームコンポーネントの `React.FormEvent` 非推奨警告（React 19 型定義）を解消。

### 関連Issue

<!-- 関連するIssue番号を記載してください -->

- なし（管理画面側の追従は #56 で別途対応）

## 技術的変更点

<!-- レビュワーに変更の流れが分かるように、どの処理をどう変更したか、どう動くのか、などを記載してください -->

- **提出ボタンが押せなくなる不具合の修正** (`SubmissionForm.tsx`)
  - 「ファイルを追加」時に言語に応じたデフォルト名（`code.js` / `code.ts` / `code.gs` / `index.html` / `style.css`）を自動設定し、既存ファイル名との衝突を回避（`buildDefaultFilename()`）。
  - 単一→複数ファイル化の初回は、1つ目のファイル名（単一時は入力欄が非表示で未入力）もデフォルト名で補完。
  - `filenameEdited` フラグを追加し、ユーザーが手動編集した場合は言語変更でファイル名を上書きしない。未編集なら言語変更でデフォルト名に追従。
- **言語選択肢の分離と共通化** (`CodeEditor.tsx`)
  - `CodeLanguage` 型に `gas` を追加（GASはJSベースのためシンタックスハイライトは `javascript()` を流用）。
  - デフォルトファイル名マップ `DEFAULT_FILENAME_BY_LANGUAGE` を `CodeEditor.tsx` に集約してエクスポートし、各フォームの重複定義を排除。
  - 提出フォームの選択肢を `JavaScript` / `TypeScript` / `GAS` / `HTML` / `CSS` に分離（`SubmissionForm.tsx`・`DemoSubmissionForm.tsx`）。
  - ファイル名プレースホルダーを `例: <言語別デフォルト名>` に変更。
- **非推奨警告の解消**
  - 全フォームの `handleSubmit` 引数型を非推奨の `React.FormEvent` から `React.SyntheticEvent<HTMLFormElement>` へ統一（`e.preventDefault()` のみ使用のため挙動は不変）。対象: SubmissionForm / DemoSubmissionForm / ContentForm / WeekForm / PhaseForm / ThemeForm。

### レビュー特記事項

<!-- レビュワーに重点的に確認してもらいたい観点や、レビュワーに伝えたい実装意図があれば記載してください -->

- 提出物の各ファイル言語は `code_files`（JSONB）に保存され DB の CHECK 制約がないため、提出フォームへの GAS 追加はマイグレーション不要です。
- 一方、管理画面（`ContentForm`）が設定する `learning_contents.code_language` には CHECK 制約 `IN ('javascript','typescript','html','css')` があるため、本PRでは管理画面側を変更していません（ラベルも「JavaScript / GAS」のまま）。管理者がコンテンツ既定言語に GAS を選べるようにする対応は #56 で別途実施します。

### TODO事項

<!-- 今回あえて修正を保留した箇所があれば記載してください -->

- 管理画面の課題編集でコンテンツ既定言語に GAS を選択可能にする（DBマイグレーション含む）→ #56

## 動作確認内容

<!-- 動作確認した内容（環境、ケース）を記載してください -->

- `bun run check`（Biome lint + format）: エラーなし
- `bunx tsc --noEmit`（型チェック・網羅性チェック含む）: エラーなし
- `bun run test`（Vitest 46件）: 全パス
- IDE診断（対象ファイル）: 警告0件
- 既存のGAS課題シード15件は `code_language='html'` のため、`javascript` の既定拡張子変更（.gs→.js）による影響なし

## その他

<!-- マージ順番の制約や急ぎ対応などの事情があれば記載してください -->

- 特になし

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語を使ってください。 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)